### PR TITLE
POC: Migrate authentication from Auth0 to Azure AD B2C

### DIFF
--- a/api/ClaimsAd/function.json
+++ b/api/ClaimsAd/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post"]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/Claims/index.js"
+}

--- a/api/ClaimsAd/index.ts
+++ b/api/ClaimsAd/index.ts
@@ -1,0 +1,92 @@
+import { AzureFunction, Context, HttpRequest } from "@azure/functions"
+import axios from "axios"
+
+const configuration = {
+  HASURA_GRAPHQL_ADMIN_SECRET: "xxx",
+  HASURA_GRAPHQL_API_URL: "https://staging.fencing.club/graphql/",
+}
+
+const httpTrigger: AzureFunction = async function (
+  context: Context,
+  req: HttpRequest
+): Promise<void> {
+  const userId = req.body.objectId
+
+  // query GetAccountClubRoles($userId: String!) {
+  //   Accounts_by_pk(Oid: $userId) {
+  //     AccountClubRoles {
+  //       ClubRole {
+  //         Name
+  //       }
+  //       ClubId
+  //       ClubRoleId
+  //     }
+  //   }
+  // }
+
+  const query = `
+    query GetAccountAppRoles($userId: String!) {
+      Accounts_by_pk(Oid: $userId) {
+        AccountAppRoles {
+          AppRole {
+            Name
+          }
+        }
+      }
+    }
+  `
+
+  try {
+    const {
+      data: { data },
+    } = await axios({
+      url: configuration.HASURA_GRAPHQL_API_URL,
+      method: "post",
+      headers: {
+        "content-type": "application/json",
+        "x-hasura-admin-secret": configuration.HASURA_GRAPHQL_ADMIN_SECRET,
+      },
+      data: {
+        query,
+        variables: {
+          userId,
+        },
+      },
+    })
+
+    let defaultRole = "user"
+    let roles = [defaultRole]
+
+    // If user is an existing user
+    if (data?.Accounts_by_pk?.AccountAppRoles) {
+      const userRoles = data.Accounts_by_pk.AccountAppRoles.map(
+        (r) => r.AppRole.Name
+      )
+      roles = [...roles, ...userRoles]
+    }
+
+    const claims = {
+      "x-hasura-default-role": defaultRole,
+      "x-hasura-allowed-roles": roles,
+      "x-hasura-user-id": userId,
+    }
+
+    context.res = {
+      // status: 200, /* Defaults to 200 */
+      body: {
+        version: "1.0.0",
+        action: "Continue",
+        extension_hasuraClaims: JSON.stringify(claims),
+      },
+    }
+  } catch (error) {
+    context.res = {
+      status: 500,
+      body: {
+        error,
+      },
+    }
+  }
+}
+
+export default httpTrigger

--- a/api/ClaimsHasura/function.json
+++ b/api/ClaimsHasura/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get"]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/ClaimsHasura/index.js"
+}

--- a/api/ClaimsHasura/index.ts
+++ b/api/ClaimsHasura/index.ts
@@ -1,0 +1,101 @@
+import { AzureFunction, Context, HttpRequest } from "@azure/functions"
+import axios from "axios"
+import jwtDecode from "jwt-decode"
+
+const configuration = {
+  HASURA_GRAPHQL_ADMIN_SECRET: "xxx",
+  HASURA_GRAPHQL_API_URL: "https://staging.fencing.club/graphql/",
+}
+
+const httpTrigger: AzureFunction = async function (
+  context: Context,
+  req: HttpRequest
+): Promise<void> {
+  context.log(req.headers)
+  if (!req.headers.authorization) {
+    context.res = {
+      status: 200,
+      body: { "x-hasura-role": "anonymous" },
+    }
+  } else {
+    const bearerToken = extractToken(req.headers.authorization)
+    context.log(req.headers.authorization)
+    context.log(bearerToken)
+    const token = (await jwtDecode(bearerToken)) as any
+    context.log(token)
+    const userId = token?.oid
+    context.log(userId)
+
+    const query = `
+    query GetAccountAppRoles($userId: String!) {
+      Accounts_by_pk(Oid: $userId) {
+        AccountAppRoles {
+          AppRole {
+            Name
+          }
+        }
+      }
+    }
+  `
+
+    try {
+      const {
+        data: { data },
+      } = await axios({
+        url: configuration.HASURA_GRAPHQL_API_URL,
+        method: "post",
+        headers: {
+          "content-type": "application/json",
+          "x-hasura-admin-secret": configuration.HASURA_GRAPHQL_ADMIN_SECRET,
+        },
+        data: {
+          query,
+          variables: {
+            userId,
+          },
+        },
+      })
+
+      let defaultRole = "user"
+      let roles = [defaultRole]
+
+      // If user is an existing user
+      if (data?.Accounts_by_pk?.AccountAppRoles) {
+        const userRoles = data.Accounts_by_pk.AccountAppRoles.map(
+          (r) => r.AppRole.Name
+        )
+        roles = [...roles, ...userRoles]
+      }
+
+      const body = {
+        "x-hasura-default-role": defaultRole,
+        "x-hasura-allowed-roles": `{${roles.join(",")}}`,
+        //"x-hasura-role": defaultRole,
+        "x-hasura-user-id": userId,
+      }
+
+      context.res = {
+        status: 200,
+        body,
+      }
+    } catch (error) {
+      context.res = {
+        status: 500,
+        body: {
+          error,
+        },
+      }
+    }
+  }
+}
+
+export default httpTrigger
+
+const extractToken = (bearerToken) => {
+  const regex = /^(Bearer) (.*)$/g
+  const match = regex.exec(bearerToken)
+  if (match && match[2]) {
+    return match[2]
+  }
+  return null
+}

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,8 @@
     "mssql": "^9.0.1",
     "request": "^2.88.2",
     "tedious": "^15.1.0",
-    "twilio": "^3.82.1"
+    "twilio": "^3.82.1",
+    "jwt-decode": "^3.1.2"
   },
   "devDependencies": {
     "@types/node": "^17.0.40",

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -876,6 +876,11 @@ jws@^4.0.0:
     jwa "^2.0.0"
     safe-buffer "^5.0.1"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "@apollo/client": "^3.6.9",
-    "@auth0/auth0-react": "^1.11.0",
+    "@azure/msal-react": "^1.5.1",
+    "@azure/msal-browser": "^2.32.1",
     "@azure/app-configuration": "^1.3.1",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",

--- a/src/components/AppShell/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppShell/components/AppHeader/AppHeader.tsx
@@ -1,4 +1,3 @@
-import { LogoutOptions, useAuth0 } from "@auth0/auth0-react"
 import styled from "@emotion/styled"
 import { useCallback } from "react"
 
@@ -8,6 +7,7 @@ import { useAccountProfile } from "$hooks/useAccountProfile"
 import { useDisclosure } from "$hooks/useDisclosure"
 import { IStyleableProps } from "$types"
 import { HeaderButton, UserMenu } from "./components"
+import { useMsal } from "@azure/msal-react"
 
 export const headerHeight = 48
 
@@ -53,15 +53,12 @@ export const AppHeader: React.FunctionComponent<IAppHeaderProps> = ({
 }) => {
   const { isOpen, onClose, onToggle } = useDisclosure()
   const { account } = useAccountProfile()
-  const { logout } = useAuth0()
+  const { instance: msal } = useMsal()
 
-  const handleLogout = useCallback(
-    (options?: LogoutOptions) => {
-      appInsights.clearAuthenticatedUserContext()
-      return logout(options)
-    },
-    [logout]
-  )
+  const handleLogout = useCallback(() => {
+    appInsights.clearAuthenticatedUserContext()
+    return msal.logout()
+  }, [msal])
 
   return (
     <>

--- a/src/components/AppShell/components/AppHeader/components/UserMenu/UserMenu.tsx
+++ b/src/components/AppShell/components/AppHeader/components/UserMenu/UserMenu.tsx
@@ -1,4 +1,3 @@
-import { LogoutOptions } from "@auth0/auth0-react"
 import styled from "@emotion/styled"
 import { ActionButton } from "@fluentui/react"
 import {
@@ -79,7 +78,7 @@ export interface IUserMenuProps {
   avatarUrl?: string
   fullName?: string
   email?: string
-  logout?: (options?: LogoutOptions | undefined) => void
+  logout?: () => void
 }
 
 export const UserMenu: React.FunctionComponent<IUserMenuProps> = ({
@@ -102,7 +101,7 @@ export const UserMenu: React.FunctionComponent<IUserMenuProps> = ({
 
   const loginRedirect = useCallback(() => {
     if (logout) {
-      logout({ returnTo: window.location.origin })
+      logout()
     }
   }, [logout])
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,17 @@
 import React from "react"
 import { render } from "react-dom"
 import { initializeIcons } from "@fluentui/react"
-
-import { Auth0Provider } from "@auth0/auth0-react"
-import { getBaseUrl } from "$lib/getBaseUrl"
-import { Provider } from "react-redux"
-import { store } from "$store"
+import { MsalProvider } from "@azure/msal-react"
 import { BrowserRouter } from "react-router-dom"
+import { Provider } from "react-redux"
+
+import { store } from "$store"
 import { AuthenticatedApp } from "$components/AuthenticatedApp"
 import { AuthorizedApolloProvider } from "$components/AuthorizedApolloProvider"
 import { AppThemeProvider } from "$components/AppThemeProvider"
 import { ApplicationInsightsProvider } from "$components/ApplicationInsightsProvider"
 import { Routes } from "./Routes"
+import { msalClient } from "$lib/msalClient"
 
 import "./styles/globals.scss"
 import "modern-normalize"
@@ -21,25 +21,19 @@ initializeIcons()
 render(
   <React.StrictMode>
     <ApplicationInsightsProvider>
-      <Auth0Provider
-        domain={import.meta.env.VITE_AUTH0_DOMAIN}
-        clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
-        redirectUri={getBaseUrl()}
-        cacheLocation="localstorage"
-        audience={import.meta.env.VITE_AUTH0_HASURA_AUDIENCE}
-      >
-        <BrowserRouter>
-          <AuthorizedApolloProvider>
-            <AppThemeProvider>
-              <Provider store={store}>
-                <AuthenticatedApp>
+      <BrowserRouter>
+        <AppThemeProvider>
+          <Provider store={store}>
+            <MsalProvider instance={msalClient}>
+              <AuthenticatedApp>
+                <AuthorizedApolloProvider>
                   <Routes />
-                </AuthenticatedApp>
-              </Provider>
-            </AppThemeProvider>
-          </AuthorizedApolloProvider>
-        </BrowserRouter>
-      </Auth0Provider>
+                </AuthorizedApolloProvider>
+              </AuthenticatedApp>
+            </MsalProvider>
+          </Provider>
+        </AppThemeProvider>
+      </BrowserRouter>
     </ApplicationInsightsProvider>
   </React.StrictMode>,
   document.getElementById("root")

--- a/src/lib/msalClient.ts
+++ b/src/lib/msalClient.ts
@@ -1,0 +1,92 @@
+import {
+  RedirectRequest,
+  SilentRequest,
+  Configuration,
+  PublicClientApplication,
+} from "@azure/msal-browser"
+
+import { getBaseUrl } from "./getBaseUrl"
+
+// domain={import.meta.env.VITE_AUTH0_DOMAIN}
+// clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
+// audience={import.meta.env.VITE_AUTH0_HASURA_AUDIENCE}
+
+// By caching this data, we can improve performance by avoiding a web request
+// This data is cached from: https://login.fencing.club/fencing.club/b2c_1_signupsignin/v2.0/.well-known/openid-configuration
+const wellKnownResponse = `
+{
+  "issuer": "https://login.fencing.club/2570213d-1e98-4c4e-a812-009627feed82/v2.0/",
+  "authorization_endpoint": "https://login.fencing.club/fencing.club/b2c_1_signupsignin/oauth2/v2.0/authorize",
+  "token_endpoint": "https://login.fencing.club/fencing.club/b2c_1_signupsignin/oauth2/v2.0/token",
+  "end_session_endpoint": "https://login.fencing.club/fencing.club/b2c_1_signupsignin/oauth2/v2.0/logout",
+  "jwks_uri": "https://login.fencing.club/fencing.club/b2c_1_signupsignin/discovery/v2.0/keys",
+  "response_modes_supported": [
+    "query",
+    "fragment",
+    "form_post"
+  ],
+  "response_types_supported": [
+    "code",
+    "code id_token",
+    "code token",
+    "code id_token token",
+    "id_token",
+    "id_token token",
+    "token",
+    "token id_token"
+  ],
+  "scopes_supported": [
+    "openid"
+  ],
+  "subject_types_supported": [
+    "pairwise"
+  ],
+  "id_token_signing_alg_values_supported": [
+    "RS256"
+  ],
+  "token_endpoint_auth_methods_supported": [
+    "client_secret_post",
+    "client_secret_basic"
+  ],
+  "claims_supported": [
+    "idp",
+    "emails",
+    "name",
+    "oid",
+    "sub",
+    "tfp",
+    "iss",
+    "iat",
+    "exp",
+    "aud",
+    "acr",
+    "nonce",
+    "auth_time"
+  ]
+}
+`
+
+export const msalLoginRequest: RedirectRequest = {
+  prompt: "select_account",
+  scopes: ["profile", "openid"],
+  state: window.location.origin,
+}
+
+export const msalSilentRequest: SilentRequest = {
+  scopes: ["user", "profile"],
+}
+
+const msalConfig: Configuration = {
+  auth: {
+    clientId: "65316ec4-56b2-4cc7-a1c0-bd5b4a5b8213", // TODO: Parameterize the ClientId
+    authority: "https://login.fencing.club/fencing.club/B2C_1_SignUpSignIn",
+    knownAuthorities: ["login.fencing.club"],
+    redirectUri: getBaseUrl(), // TODO: Redirect to Azure Function if it's a preview env
+    authorityMetadata: wellKnownResponse,
+  },
+  cache: {
+    cacheLocation: "localStorage",
+  },
+}
+
+export const msalClient = new PublicClientApplication(msalConfig)

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,26 +58,6 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@auth0/auth0-react@^1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@auth0/auth0-react/-/auth0-react-1.11.0.tgz#718ea99b52cc7cffb354dda2af1991fb104b6a75"
-  integrity sha512-zt8Q4XRj+rwWPRAseXrBQY9P+MXy1S6rbznLsbsiU12DY47AUtDh4psSUyt4f5AzD9SScEGkf22iB0rGXNDDDw==
-  dependencies:
-    "@auth0/auth0-spa-js" "^1.22.2"
-
-"@auth0/auth0-spa-js@^1.22.2":
-  version "1.22.4"
-  resolved "https://registry.yarnpkg.com/@auth0/auth0-spa-js/-/auth0-spa-js-1.22.4.tgz#0054b13b27155cbd1d92da82306749e156ee837e"
-  integrity sha512-iOboSV+aUsExV1onKvGKEqi626sjJt+61c3EvA4mkn9RM7RV9RMjPI+cInNFHWjwAd2Sdi3LqBj6/MfcHh69dg==
-  dependencies:
-    abortcontroller-polyfill "^1.7.3"
-    browser-tabs-lock "^1.2.15"
-    core-js "^3.24.0"
-    es-cookie "~1.3.2"
-    fast-text-encoding "^1.0.4"
-    promise-polyfill "^8.2.3"
-    unfetch "^4.2.0"
-
 "@azure/abort-controller@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@azure/abort-controller/-/abort-controller-1.1.0.tgz#788ee78457a55af8a1ad342acb182383d2119249"
@@ -290,6 +270,13 @@
   dependencies:
     "@azure/msal-common" "^6.3.0"
 
+"@azure/msal-browser@^2.32.1":
+  version "2.32.1"
+  resolved "https://registry.yarnpkg.com/@azure/msal-browser/-/msal-browser-2.32.1.tgz#785670d5bd066690e313ba32cd4638a473675598"
+  integrity sha512-2G3B12ZEIpiimi6/Yqq7KLk4ud1zZWoHvVd2kJ2VthN1HjMsZjdMUxeHkwMWaQ6RzO6mv9rZiuKmRX64xkXW9g==
+  dependencies:
+    "@azure/msal-common" "^9.0.1"
+
 "@azure/msal-common@^4.5.1":
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-4.5.1.tgz#f35af8b634ae24aebd0906deb237c0db1afa5826"
@@ -302,6 +289,11 @@
   resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-6.3.0.tgz#a0cdb6be1ae3cfdc5acf3c32979375a0fef433b2"
   integrity sha512-ZyLq9GdnLBi/83YpysE86TFKbA0TuvfNAN5Psqu20cdAjLo/4rw4ttiItdh1G//XeGErHk9qn57gi2AYU1b5/Q==
 
+"@azure/msal-common@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-9.0.1.tgz#a89c3e156a60d5952aed17b80d3f69e40385daa0"
+  integrity sha512-eNNHIW/cwPTZDWs9KtYgb1X6gtQ+cC+FGX2YN+t4AUVsBdUbqlMTnUs6/c/VBxC2AAGIhgLREuNnO3F66AN2zQ==
+
 "@azure/msal-node@^1.3.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-1.9.0.tgz#d42d848d2997aa9559d6bd6e1ec4f602b29dc1ba"
@@ -312,6 +304,11 @@
     https-proxy-agent "^5.0.0"
     jsonwebtoken "^8.5.1"
     uuid "^8.3.0"
+
+"@azure/msal-react@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@azure/msal-react/-/msal-react-1.5.1.tgz#95ffd3933dcf46f739c0c84cfe9a2bc68901394d"
+  integrity sha512-4R05uUc5x0dHqtHtVGDvQDclOXg/0V1S3PFDnca73UHzlRe+RjeB/zLCY9RbcUiPv8Bdhpvj6KPL54KgaOTdpA==
 
 "@azure/static-web-apps-cli@^1.0.2":
   version "1.0.2"
@@ -3783,11 +3780,6 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-abortcontroller-polyfill@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz#1b5b487bd6436b5b764fd52a612509702c3144b5"
-  integrity sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==
-
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -4236,13 +4228,6 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browser-tabs-lock@^1.2.15:
-  version "1.2.15"
-  resolved "https://registry.yarnpkg.com/browser-tabs-lock/-/browser-tabs-lock-1.2.15.tgz#d5012e652e2a0cb4eba471b0a2300c2fa5d92788"
-  integrity sha512-J8K9vdivK0Di+b8SBdE7EZxDr88TnATing7XoLw6+nFkXMQ6sVBh92K3NQvZlZU91AIkFRi0w3sztk5Z+vsswA==
-  dependencies:
-    lodash ">=4.17.21"
-
 browserslist@^4.20.2, browserslist@^4.20.3:
   version "4.20.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.3.tgz#eb7572f49ec430e054f56d52ff0ebe9be915f8bf"
@@ -4681,11 +4666,6 @@ core-js-pure@^3.20.2:
   version "3.22.7"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.22.7.tgz#f58489d9b309fa7b26486a0f70d4ec19a418084e"
   integrity sha512-wTriFxiZI+C8msGeh7fJcbC/a0V8fdInN1oS2eK79DMBGs8iIJiXhtFJCiT3rBa8w6zroHWW3p8ArlujZ/Mz+w==
-
-core-js@^3.24.0:
-  version "3.25.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.25.1.tgz#5818e09de0db8956e16bf10e2a7141e931b7c69c"
-  integrity sha512-sr0FY4lnO1hkQ4gLDr24K0DGnweGO1QwSj5BpfQjpSJPdqWalja4cTps29Y/PJVG/P7FYlPDkH3hO+Tr0CvDgQ==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -5153,11 +5133,6 @@ es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19
     string.prototype.trimend "^1.0.5"
     string.prototype.trimstart "^1.0.5"
     unbox-primitive "^1.0.2"
-
-es-cookie@~1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/es-cookie/-/es-cookie-1.3.2.tgz#80e831597f72a25721701bdcb21d990319acd831"
-  integrity sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q==
 
 es-shim-unscopables@^1.0.0:
   version "1.0.0"
@@ -5682,11 +5657,6 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
-
-fast-text-encoding@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.4.tgz#bf1898ad800282a4e53c0ea9690704dd26e4298e"
-  integrity sha512-x6lDDm/tBAzX9kmsPcZsNbvDs3Zey3+scsxaZElS8xWLgUMAg/oFLeewfUz0mu1CblHhhsu15jGkraldkFh8KQ==
 
 fastq@^1.6.0:
   version "1.13.0"
@@ -7058,7 +7028,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash@>=4.17.21, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@~4.17.0:
+lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@~4.17.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8094,11 +8064,6 @@ progress@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-
-promise-polyfill@^8.2.3:
-  version "8.2.3"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.3.tgz#2edc7e4b81aff781c88a0d577e5fe9da822107c6"
-  integrity sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==
 
 promise@^7.1.1:
   version "7.3.1"
@@ -9331,11 +9296,6 @@ undici@^5.8.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.10.0.tgz#dd9391087a90ccfbd007568db458674232ebf014"
   integrity sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==
-
-unfetch@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
-  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Auth0 provides an easy to implement authentication system with a great polished user experience out-of-the-box. However, to support 50k users would be very expensive, and we would need to pay the fee for each environment tenant.

Azure AD B2C is not a great platform, and leaves lots to be desired as far as DX and user experience. But the pricing is FREE for up to 50k users, and negligible cost beyond that. Additionally, we could have as many tenants as we like and it would be free. Having the auth resources co-located next to the other cloud resources in Azure would make everything easier to administer.

The drawback however, is that we would likely need to hire a vendor to redesign the login flows from scratch because Azure AD user flows provided are beyond horrendous.