### PR TITLE
Migrate all FunctionComponent declarations to React 18 compatible types

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -23,7 +23,7 @@ const EditEvaluationPage = loadable(
 const UsersPage = loadable(() => import("./pages/users"))
 const TournamentsPage = loadable(() => import("./pages/tournaments"))
 
-export const Routes: React.FunctionComponent = () => {
+export function Routes() {
   const { isEnabled: isUsersPageEnabled } = useFeatureFlag({
     key: "users-page",
     label: import.meta.env.MODE,

--- a/src/components/AppShell/AppShell.tsx
+++ b/src/components/AppShell/AppShell.tsx
@@ -7,6 +7,7 @@ import { AppBreadcrumbs } from "./components/AppBreadcrumbs"
 import { useSitemapGroups } from "$hooks/sitemap"
 import { useAccountAppRoles } from "$hooks/authorization/useAccountAppRoles"
 import { useAccountClubRoles } from "$hooks/authorization/useAccountClubRoles"
+import { PropsWithChildren } from "react"
 
 const AppRoot = styled.div`
   display: grid;
@@ -42,7 +43,7 @@ const Page = styled(AppPage)`
   grid-area: body;
 `
 
-export const AppShell: React.FunctionComponent = ({ children }) => {
+export function AppShell({ children }: PropsWithChildren<{}>) {
   const appRoles = useAccountAppRoles()
   const clubRoles = useAccountClubRoles()
 

--- a/src/components/AppShell/components/AppBreadcrumbs/AppBreadcrumbs.tsx
+++ b/src/components/AppShell/components/AppBreadcrumbs/AppBreadcrumbs.tsx
@@ -24,9 +24,7 @@ export interface IAppBreadcrumbsProps {
   crumbs: IBreadcrumbItem[]
 }
 
-export const AppBreadcrumbs: React.FunctionComponent<IAppBreadcrumbsProps> = ({
-  crumbs,
-}) => {
+export function AppBreadcrumbs({ crumbs }: IAppBreadcrumbsProps) {
   return (
     <BreadcrumbBar
       items={crumbs}

--- a/src/components/AppShell/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppShell/components/AppHeader/AppHeader.tsx
@@ -48,9 +48,7 @@ const CenterRegion = styled.div`
 
 export interface IAppHeaderProps extends IStyleableProps {}
 
-export const AppHeader: React.FunctionComponent<IAppHeaderProps> = ({
-  className,
-}) => {
+export function AppHeader({ className }: IAppHeaderProps) {
   const { isOpen, onClose, onToggle } = useDisclosure()
   const { account } = useAccountProfile()
   const { logout } = useAuth0()
@@ -82,7 +80,6 @@ export const AppHeader: React.FunctionComponent<IAppHeaderProps> = ({
 
           {/* TODO: Pass all user menu props up to the AppShell level */}
           <UserMenu
-            avatarUrl={account.Picture}
             fullName={account.FullName}
             email={account.Email}
             logout={handleLogout}

--- a/src/components/AppShell/components/AppHeader/components/HeaderButton/HeaderButton.tsx
+++ b/src/components/AppShell/components/AppHeader/components/HeaderButton/HeaderButton.tsx
@@ -11,7 +11,7 @@ export interface IHeaderButtonProps
   icon?: string
 }
 
-const Button: React.FunctionComponent<IHeaderButtonProps> = (props) => {
+function Button(props: IHeaderButtonProps) {
   const { icon, variant, children, ...buttonProps } = props
 
   return (

--- a/src/components/AppShell/components/AppHeader/components/UserMenu/UserMenu.tsx
+++ b/src/components/AppShell/components/AppHeader/components/UserMenu/UserMenu.tsx
@@ -76,18 +76,12 @@ const OutlinedAvatar = styled(PersonaAvatar)`
 `
 
 export interface IUserMenuProps {
-  avatarUrl?: string
   fullName?: string
   email?: string
   logout?: (options?: LogoutOptions | undefined) => void
 }
 
-export const UserMenu: React.FunctionComponent<IUserMenuProps> = ({
-  avatarUrl,
-  fullName,
-  email,
-  logout,
-}) => {
+export function UserMenu({ fullName, email, logout }: IUserMenuProps) {
   const avatarRef = useRef(null)
   const linkShims = useLinkShims()
   const { isOpen, onToggle, onClose, setIsOpen } = useDisclosure(false)

--- a/src/components/AppShell/components/AppNav/AppNav.tsx
+++ b/src/components/AppShell/components/AppNav/AppNav.tsx
@@ -65,10 +65,7 @@ export interface IAppNavProps extends IStyleableProps {
   links: INavLinkGroup[]
 }
 
-export const AppNav: React.FunctionComponent<IAppNavProps> = ({
-  links,
-  className,
-}) => {
+export function AppNav({ links, className }: IAppNavProps) {
   const { isOpen, onToggle } = useDisclosure(true)
 
   const onRenderGroupHeader = useCallback(

--- a/src/components/AppShell/components/AppNav/components/Hamburger/Hamburger.tsx
+++ b/src/components/AppShell/components/AppNav/components/Hamburger/Hamburger.tsx
@@ -11,13 +11,12 @@ const HamburgerContainer = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.palette.neutralLight};
 `
 
-export const Hamburger: React.FunctionComponent<IButtonProps> = ({
-  children,
-  className,
-  theme,
-  ...props
-}) => (
-  <HamburgerContainer className={className}>
-    <HamburgerButton {...props} />
-  </HamburgerContainer>
-)
+export function Hamburger(props: IButtonProps) {
+  const { children, className, theme, ...buttonProps } = props
+
+  return (
+    <HamburgerContainer className={className}>
+      <HamburgerButton {...buttonProps} />
+    </HamburgerContainer>
+  )
+}

--- a/src/components/AppShell/components/AppPage/AppPage.tsx
+++ b/src/components/AppShell/components/AppPage/AppPage.tsx
@@ -16,11 +16,7 @@ export interface IAppPageProps
   extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
     IStyleableProps {}
 
-export const AppPage: React.FunctionComponent<IAppPageProps> = ({
-  children,
-  className,
-  ...props
-}) => {
+export function AppPage({ children, className, ...props }: IAppPageProps) {
   return (
     <PageContainer className={className} {...props}>
       <PageContent>{children}</PageContent>

--- a/src/components/AppShell/components/PageLayouts/BasePageLayout.tsx
+++ b/src/components/AppShell/components/PageLayouts/BasePageLayout.tsx
@@ -1,18 +1,15 @@
 import { PageTitle } from "$components/PageTitle"
 import { useTitle } from "$hooks/useTitle"
+import { PropsWithChildren } from "react"
 
-export type BasePageLayoutProps = {
+export type BasePageLayoutProps = PropsWithChildren<{
   title: string
   skipTitleHeading?: boolean
   className?: string
-}
+}>
 
-export const BasePageLayout: React.FunctionComponent<BasePageLayoutProps> = ({
-  children,
-  className,
-  skipTitleHeading,
-  title,
-}) => {
+export function BasePageLayout(props: BasePageLayoutProps) {
+  const { children, className, skipTitleHeading, title } = props
   useTitle(title)
 
   return (

--- a/src/components/AppShell/components/PageLayouts/DefaultPageLayout.tsx
+++ b/src/components/AppShell/components/PageLayouts/DefaultPageLayout.tsx
@@ -5,6 +5,6 @@ const PageLayout = styled(BasePageLayout)`
   margin: ${({ theme }) => theme.spacing.l2};
 `
 
-export const DefaultPageLayout: React.FunctionComponent<
-  BasePageLayoutProps
-> = ({ children, ...props }) => <PageLayout {...props}>{children}</PageLayout>
+export function DefaultPageLayout({ children, ...props }: BasePageLayoutProps) {
+  return <PageLayout {...props}>{children}</PageLayout>
+}

--- a/src/components/AppShell/components/PageLayouts/PageToolbar.tsx
+++ b/src/components/AppShell/components/PageLayouts/PageToolbar.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled"
 import { IStackTokens, Stack } from "@fluentui/react"
+import { PropsWithChildren } from "react"
 
 const ToolbarContainer = styled.div`
   padding: ${({ theme }) => theme.fluentV9.spacingVerticalS}
@@ -9,7 +10,7 @@ const ToolbarContainer = styled.div`
 
 const toolbarTokens: IStackTokens = { childrenGap: 8 }
 
-export const PageToolbar: React.FunctionComponent = ({ children }) => {
+export function PageToolbar({ children }: PropsWithChildren<{}>) {
   return (
     <ToolbarContainer role="complementary">
       <Stack horizontal={true} horizontalAlign="start" tokens={toolbarTokens}>
@@ -19,8 +20,10 @@ export const PageToolbar: React.FunctionComponent = ({ children }) => {
   )
 }
 
-export const PageToolbarGrow: React.FunctionComponent = () => (
-  <Stack.Item grow>
-    <></>
-  </Stack.Item>
-)
+export function PageToolbarGrow() {
+  return (
+    <Stack.Item grow>
+      <></>
+    </Stack.Item>
+  )
+}

--- a/src/components/AppThemeProvider/AppThemeProvider.tsx
+++ b/src/components/AppThemeProvider/AppThemeProvider.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider as FluentProvider } from "@fluentui/react"
-import React, { useMemo, useState } from "react"
+import React, { PropsWithChildren, useMemo, useState } from "react"
 import { DefaultTheme, DarkTheme } from "@fluentui/theme-samples"
 import {
   webLightTheme,
@@ -25,7 +25,7 @@ export const AppThemeContext = createContext<IAppThemeContextValue | undefined>(
   undefined
 )
 
-export const AppThemeProvider: React.FunctionComponent = ({ children }) => {
+export function AppThemeProvider({ children }: PropsWithChildren<{}>) {
   const [params] = useSearchParams()
   const defaultTheme = (params.get("theme") as AppTheme) ?? "light"
 

--- a/src/components/AppThemeProvider/components/EmotionalSupport.tsx
+++ b/src/components/AppThemeProvider/components/EmotionalSupport.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider } from "@emotion/react"
 import styled from "@emotion/styled"
-import React from "react"
+import React, { PropsWithChildren } from "react"
 
 import { IAppTheme } from "../AppThemeProvider.types"
 
@@ -8,14 +8,14 @@ const BodyGrow = styled.div`
   height: 100vh;
 `
 
-export interface IEmotionalSupportProps {
+export type EmotionalSupportProps = PropsWithChildren<{
   theme: IAppTheme
-}
+}>
 
-export const EmotionalSupport: React.FunctionComponent<
-  IEmotionalSupportProps
-> = ({ children, theme }) => (
-  <ThemeProvider theme={theme}>
-    <BodyGrow>{children}</BodyGrow>
-  </ThemeProvider>
-)
+export function EmotionalSupport({ children, theme }: EmotionalSupportProps) {
+  return (
+    <ThemeProvider theme={theme}>
+      <BodyGrow>{children}</BodyGrow>
+    </ThemeProvider>
+  )
+}

--- a/src/components/ApplicationInsightsProvider/ApplicationInsightsProvider.tsx
+++ b/src/components/ApplicationInsightsProvider/ApplicationInsightsProvider.tsx
@@ -4,6 +4,7 @@ import {
   AppInsightsErrorBoundary,
 } from "@microsoft/applicationinsights-react-js"
 import { ApplicationInsights } from "@microsoft/applicationinsights-web"
+import { PropsWithChildren } from "react"
 
 export const reactPlugin = new ReactPlugin()
 export const appInsights = new ApplicationInsights({
@@ -29,9 +30,9 @@ export const appInsights = new ApplicationInsights({
 
 appInsights.loadAppInsights()
 
-export const ApplicationInsightsProvider: React.FunctionComponent = ({
+export function ApplicationInsightsProvider({
   children,
-}) => {
+}: PropsWithChildren<{}>) {
   return (
     <AppInsightsContext.Provider value={reactPlugin}>
       {/* @ts-ignore  */}

--- a/src/components/AssessmentCard/AssessmentCard.tsx
+++ b/src/components/AssessmentCard/AssessmentCard.tsx
@@ -11,9 +11,7 @@ interface IAssessmentCardProps {
   assessment: IAssessmentMetadata
 }
 
-export const AssessmentCard: React.FunctionComponent<IAssessmentCardProps> = ({
-  assessment,
-}) => {
+export function AssessmentCard({ assessment }: IAssessmentCardProps) {
   const {
     id,
     title,

--- a/src/components/AssessmentCard/AssessmentCardSkeleton.tsx
+++ b/src/components/AssessmentCard/AssessmentCardSkeleton.tsx
@@ -73,7 +73,7 @@ const attributionShimmer = [
   },
 ]
 
-export const AssessmentCardSkeleton: React.FunctionComponent = () => {
+export function AssessmentCardSkeleton() {
   return (
     <Card>
       <CardHeader

--- a/src/components/AssessmentMetricsForm/AssessmentMetricsForm.tsx
+++ b/src/components/AssessmentMetricsForm/AssessmentMetricsForm.tsx
@@ -19,9 +19,8 @@ interface IAssessmentMetricsFormProps {
   isLoading?: boolean
 }
 
-export const AssessmentMetricsForm: React.FunctionComponent<
-  IAssessmentMetricsFormProps
-> = ({ metrics, form, disabled, required, onCancel, isLoading }) => {
+export function AssessmentMetricsForm(props: IAssessmentMetricsFormProps) {
+  const { metrics, form, disabled, required, onCancel, isLoading } = props
   const { control } = form
 
   // Sort the metrics by the proper order number

--- a/src/components/AssessmentMetricsForm/MetricForm.tsx
+++ b/src/components/AssessmentMetricsForm/MetricForm.tsx
@@ -25,9 +25,7 @@ interface IMetricFormProps {
   form: UseFormReturn<FieldValues, any>
 }
 
-export const MetricForm: React.FunctionComponent<IMetricFormProps> = (
-  props
-) => {
+export function MetricForm(props: IMetricFormProps) {
   const {
     id,
     title,

--- a/src/components/AssessmentResponseList/AssessmentResponseList.tsx
+++ b/src/components/AssessmentResponseList/AssessmentResponseList.tsx
@@ -42,9 +42,9 @@ export interface IAssessmentResponseListProps {
   assessmentId: string
 }
 
-export const AssessmentResponseList: React.FunctionComponent<
-  IAssessmentResponseListProps
-> = ({ assessmentId }) => {
+export function AssessmentResponseList({
+  assessmentId,
+}: IAssessmentResponseListProps) {
   const [selectedEvaluation, setSelectedEvaluation] = useState<
     AssessmentEvaluation | undefined
   >(undefined)

--- a/src/components/AuthenticatedApp/AuthenticatedApp.tsx
+++ b/src/components/AuthenticatedApp/AuthenticatedApp.tsx
@@ -1,8 +1,8 @@
 import { appInsights } from "$components/ApplicationInsightsProvider"
 import { useAuth0 } from "@auth0/auth0-react"
-import React from "react"
+import React, { PropsWithChildren } from "react"
 
-export const AuthenticatedApp: React.FunctionComponent = ({ children }) => {
+export function AuthenticatedApp({ children }: PropsWithChildren<{}>) {
   const { loginWithRedirect, isLoading, user, error } = useAuth0()
 
   if (error) {

--- a/src/components/AuthorizedApolloProvider/AuthorizedApolloProvider.tsx
+++ b/src/components/AuthorizedApolloProvider/AuthorizedApolloProvider.tsx
@@ -1,9 +1,8 @@
 import { useApollo } from "$lib/apolloClient"
 import { ApolloProvider } from "@apollo/client"
+import { PropsWithChildren } from "react"
 
-export const AuthorizedApolloProvider: React.FunctionComponent = ({
-  children,
-}) => {
+export function AuthorizedApolloProvider({ children }: PropsWithChildren<{}>) {
   const client = useApollo()
 
   return <ApolloProvider client={client}>{children}</ApolloProvider>

--- a/src/components/BackLink/BackLink.tsx
+++ b/src/components/BackLink/BackLink.tsx
@@ -1,14 +1,12 @@
 import { ChevronLeftRegular } from "@fluentui/react-icons"
+import { PropsWithChildren } from "react"
 import { IconLink } from "./BackLink.styles"
 
-interface IBackLink {
+type IBackLink = PropsWithChildren<{
   onClick: () => void
-}
+}>
 
-export const BackLink: React.FunctionComponent<IBackLink> = ({
-  onClick,
-  children,
-}) => {
+export function BackLink({ onClick, children }: IBackLink) {
   return (
     <IconLink onClick={onClick} as="button">
       <ChevronLeftRegular />

--- a/src/components/BigMessage/BigMessage.tsx
+++ b/src/components/BigMessage/BigMessage.tsx
@@ -6,15 +6,13 @@ import { ThemedImage } from "$components/ThemedImage"
 // TODO: Parameterize these as props
 import errorLightSvg from "$assets/errorLight.svg"
 import errorDarkSvg from "$assets/errorDark.svg"
+import { PropsWithChildren } from "react"
 
-export type BigMessageProps = {
+export type BigMessageProps = PropsWithChildren<{
   heading: string
-}
+}>
 
-export const BigMessage: React.FunctionComponent<BigMessageProps> = ({
-  heading,
-  children,
-}) => {
+export function BigMessage({ heading, children }: BigMessageProps) {
   return (
     <Stack horizontalAlign="center" style={{ marginTop: "10vh" }}>
       <ThemedImage

--- a/src/components/Cards/FencerProfileCard/AddFencerCard.tsx
+++ b/src/components/Cards/FencerProfileCard/AddFencerCard.tsx
@@ -16,7 +16,7 @@ const VerticallyCentered = styled(Stack)`
   height: 100%;
 `
 
-export const AddFencerCard: React.FunctionComponent = () => {
+export function AddFencerCard() {
   const {
     isOpen: isEditFencerDialogOpen,
     onClose: onCloseEditFencerDialog,

--- a/src/components/Cards/FencerProfileCard/FencerProfileCard.tsx
+++ b/src/components/Cards/FencerProfileCard/FencerProfileCard.tsx
@@ -1,7 +1,7 @@
 import { IButtonProps, Icon, Stack } from "@fluentui/react"
 import { Avatar, Badge } from "@fluentui/react-components"
 import dayjs from "dayjs"
-import { useCallback, useMemo } from "react"
+import { PropsWithChildren, useCallback, useMemo } from "react"
 
 import { useDeleteFencerByIdMutation } from "$queries"
 import { DetailsItem } from "./components"
@@ -22,15 +22,15 @@ import { cacheEvicter } from "$lib/apolloClient"
 import { formatFullName } from "$lib/formatFullName"
 import { formatPhoneNumber } from "$lib/formatPhoneNumber"
 
-export interface IFencerCardProps {
+export type FencerCardProps = PropsWithChildren<{
   fencer: AccountFencer
   primaryFencerId?: string
-}
+}>
 
-export const FencerProfileCard: React.FunctionComponent<IFencerCardProps> = ({
+export function FencerProfileCard({
   fencer,
   primaryFencerId,
-}) => {
+}: FencerCardProps) {
   const {
     AssociationMemberId,
     Email,

--- a/src/components/Cards/FencerProfileCard/components/DetailsItem/DetailsItem.tsx
+++ b/src/components/Cards/FencerProfileCard/components/DetailsItem/DetailsItem.tsx
@@ -5,6 +5,7 @@ import {
   PresenceBadgeProps,
   Text,
 } from "@fluentui/react-components"
+import { PropsWithChildren } from "react"
 
 const TextTruncated = styled(Text)`
   overflow: hidden;
@@ -22,25 +23,23 @@ const DetailsBadge = styled(PresenceBadge)`
   margin-left: 0.5rem;
 `
 
-export interface IDetailsItemProps {
+export type DetailsItemProps = PropsWithChildren<{
   iconName: string
   iconLabel: string
   title: string
   badgeProps?: PresenceBadgeProps
-}
+}>
 
-export const DetailsItem: React.FunctionComponent<IDetailsItemProps> = ({
-  iconName,
-  iconLabel,
-  badgeProps,
-  title,
-  children,
-}) => (
-  <Stack horizontal verticalAlign="center">
-    <DetailsIcon iconName={iconName} title={iconLabel} />
-    <TextTruncated title={title}>
-      <>{children}</>
-      <>{badgeProps ? <DetailsBadge {...badgeProps} /> : null}</>
-    </TextTruncated>
-  </Stack>
-)
+export function DetailsItem(props: DetailsItemProps) {
+  const { iconName, iconLabel, badgeProps, title, children } = props
+
+  return (
+    <Stack horizontal verticalAlign="center">
+      <DetailsIcon iconName={iconName} title={iconLabel} />
+      <TextTruncated title={title}>
+        <>{children}</>
+        <>{badgeProps ? <DetailsBadge {...badgeProps} /> : null}</>
+      </TextTruncated>
+    </Stack>
+  )
+}

--- a/src/components/Cards/HorizontalCard/HorizontalCard.tsx
+++ b/src/components/Cards/HorizontalCard/HorizontalCard.tsx
@@ -17,26 +17,27 @@ const horizontalTokens = { childrenGap: "0.5rem" }
 
 export interface IHorizontalCardProps extends IStyleableProps {
   actions?: IButtonProps[]
+  children: React.ReactNode
 }
 
-export const HorizontalCard: React.FunctionComponent<IHorizontalCardProps> = ({
-  children,
-  className,
-  actions,
-}) => (
-  <Card className={className}>
-    <Stack horizontal>
-      <Stack tokens={horizontalTokens} verticalFill grow>
-        {children}
-      </Stack>
+export function HorizontalCard(props: IHorizontalCardProps) {
+  const { children, className, actions } = props
 
-      {actions?.length && (
-        <CardControls>
-          {actions.map((props, index) => (
-            <IconButton key={index} {...props} />
-          ))}
-        </CardControls>
-      )}
-    </Stack>
-  </Card>
-)
+  return (
+    <Card className={className}>
+      <Stack horizontal>
+        <Stack tokens={horizontalTokens} verticalFill grow>
+          {children}
+        </Stack>
+
+        {actions?.length && (
+          <CardControls>
+            {actions.map((props, index) => (
+              <IconButton key={index} {...props} />
+            ))}
+          </CardControls>
+        )}
+      </Stack>
+    </Card>
+  )
+}

--- a/src/components/Cards/MemberDetailsCard/MemberDetailsCard.tsx
+++ b/src/components/Cards/MemberDetailsCard/MemberDetailsCard.tsx
@@ -5,6 +5,7 @@ import { IButtonProps } from "@fluentui/react"
 import { Text } from "@fluentui/react-components"
 import dayjs from "dayjs"
 import { PersonaAvatar } from "../../PersonaAvatar"
+import { PropsWithChildren } from "react"
 
 export const MemberDetailsList = styled.ul`
   display: grid;
@@ -22,16 +23,16 @@ export const MemberDetailsList = styled.ul`
   }
 `
 
-export const MemberDetailItem: React.FunctionComponent<
-  IMemberDetailItemProps
-> = ({ title, value }) => (
-  <li>
-    <Text size={100} weight="semibold">
-      {title}
-    </Text>
-    <Text size={200}>{value ?? "N/A"}</Text>
-  </li>
-)
+export function MemberDetailItem({ title, value }: MemberDetailItemProps) {
+  return (
+    <li>
+      <Text size={100} weight="semibold">
+        {title}
+      </Text>
+      <Text size={200}>{value ?? "N/A"}</Text>
+    </li>
+  )
+}
 
 const ThinCard = styled(HorizontalCard)`
   padding: ${({ theme }) => theme.spacing.s1};
@@ -42,10 +43,10 @@ const MemberPersona = styled(PersonaAvatar)`
   max-width: 245px;
 `
 
-export interface IMemberDetailItemProps {
+export type MemberDetailItemProps = PropsWithChildren<{
   title: string
   value?: string | number | null
-}
+}>
 
 export type MemberDetails = {
   fullName?: string
@@ -62,9 +63,9 @@ export interface IMemberDetailsCardProps extends IStyleableProps {
   details: MemberDetails
   actions?: IButtonProps[]
 }
-export const MemberDetailsCard: React.FunctionComponent<
-  IMemberDetailsCardProps
-> = ({ className, details, actions }) => {
+export function MemberDetailsCard(props: IMemberDetailsCardProps) {
+  const { className, details, actions } = props
+
   const {
     fullName,
     secondaryText,

--- a/src/components/Cards/PaymentMethodCard/PaymentMethodCard.tsx
+++ b/src/components/Cards/PaymentMethodCard/PaymentMethodCard.tsx
@@ -1,4 +1,4 @@
-import { IPaymentMethodProps, PaymentMethod } from "$components/PaymentMethod"
+import { PaymentMethodProps, PaymentMethod } from "$components/PaymentMethod"
 import styled from "@emotion/styled"
 import { IButtonProps } from "@fluentui/react"
 import { PaymentMethod as PM } from "@stripe/stripe-js"
@@ -22,14 +22,12 @@ const PaymentContainer = styled(HorizontalCard)`
   }
 `
 
-export interface IPaymentMethodCardProps extends IPaymentMethodProps {
+export interface IPaymentMethodCardProps extends PaymentMethodProps {
   onEditClick?: (event: any, card: PM.Card) => void
   onDeleteClick?: (event: any, card: PM.Card) => void
 }
 
-export const PaymentMethodCard: React.FunctionComponent<
-  IPaymentMethodCardProps
-> = (props) => {
+export function PaymentMethodCard(props: IPaymentMethodCardProps) {
   const { card, onEditClick, onDeleteClick } = props
 
   const paymentActions: IButtonProps[] = useMemo(

--- a/src/components/Cards/VerticalCard/VerticalCard.tsx
+++ b/src/components/Cards/VerticalCard/VerticalCard.tsx
@@ -16,26 +16,27 @@ const verticalTokens = { childrenGap: "0.5rem" }
 
 export interface IVerticalCardProps extends IStyleableProps {
   actions?: IButtonProps[]
+  children?: React.ReactNode
 }
 
-export const VerticalCard: React.FunctionComponent<IVerticalCardProps> = ({
-  children,
-  className,
-  actions,
-}) => (
-  <CardThinnedBottom className={className}>
-    <Stack tokens={verticalTokens} verticalFill grow>
-      <Stack tokens={verticalTokens} verticalFill grow>
-        {children}
-      </Stack>
+export function VerticalCard(props: IVerticalCardProps) {
+  const { children, className, actions } = props
 
-      {actions?.length ? (
-        <CardControls horizontal horizontalAlign="end">
-          {actions.map((props, index) => (
-            <IconButton key={index} {...props} />
-          ))}
-        </CardControls>
-      ) : undefined}
-    </Stack>
-  </CardThinnedBottom>
-)
+  return (
+    <CardThinnedBottom className={className}>
+      <Stack tokens={verticalTokens} verticalFill grow>
+        <Stack tokens={verticalTokens} verticalFill grow>
+          {children}
+        </Stack>
+
+        {actions?.length ? (
+          <CardControls horizontal horizontalAlign="end">
+            {actions.map((props, index) => (
+              <IconButton key={index} {...props} />
+            ))}
+          </CardControls>
+        ) : undefined}
+      </Stack>
+    </CardThinnedBottom>
+  )
+}

--- a/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -1,26 +1,29 @@
 import { Dialog, DialogFooter, DialogType } from "@fluentui/react"
 import { Button, FluentProvider } from "@fluentui/react-components"
+import { PropsWithChildren } from "react"
 
 import { DialogSpinner } from "./ConfirmDialog.styles"
 
-export interface IConfirmDialogProps {
+export type ConfirmDialogProps = PropsWithChildren<{
   hidden: boolean
   isProcessing?: boolean
   onConfirmed: () => void
   onClose: () => void
   confirmLabel: string
   title: string
-}
+}>
 
-export const ConfirmDialog: React.FunctionComponent<IConfirmDialogProps> = ({
-  hidden,
-  isProcessing,
-  children,
-  onConfirmed,
-  onClose,
-  confirmLabel,
-  title,
-}) => {
+export function ConfirmDialog(props: ConfirmDialogProps) {
+  const {
+    hidden,
+    isProcessing,
+    children,
+    onConfirmed,
+    onClose,
+    confirmLabel,
+    title,
+  } = props
+
   return (
     <Dialog
       hidden={hidden}

--- a/src/components/ConnectionsManager/ConnectionsManager.tsx
+++ b/src/components/ConnectionsManager/ConnectionsManager.tsx
@@ -8,9 +8,7 @@ import { TabText, IndentedAccordionPanel } from "$components/Forms"
 import { CalendarLinker } from "./components"
 import { AssociationMembershipLinker } from "./components"
 
-export const ConnectionsManager: React.FunctionComponent = () => {
-  // TODO: Add check for user role
-
+export function ConnectionsManager() {
   return (
     <div style={{ maxWidth: 600 }}>
       <TabText block>Manage external connections to your account.</TabText>

--- a/src/components/ConnectionsManager/components/AssociationMembershipLinker/AssociationMembershipLinker.tsx
+++ b/src/components/ConnectionsManager/components/AssociationMembershipLinker/AssociationMembershipLinker.tsx
@@ -15,7 +15,7 @@ const MembershipCard = styled(MemberDetailsCard)`
   margin-bottom: 0.5rem;
 `
 
-export const AssociationMembershipLinker: React.FunctionComponent = () => {
+export function AssociationMembershipLinker() {
   const { account, refetch: refetchProfile } = useAccountProfile()
   const { isOpen, onOpen, onClose } = useDisclosure(false)
 

--- a/src/components/ConnectionsManager/components/CalendarLinker/CalendarLinker.tsx
+++ b/src/components/ConnectionsManager/components/CalendarLinker/CalendarLinker.tsx
@@ -13,7 +13,7 @@ import { useDisclosure } from "$hooks/useDisclosure"
 
 dayjs.extend(utc)
 
-export const CalendarLinker: React.FunctionComponent = () => {
+export function CalendarLinker() {
   const { isOpen, onOpen, onClose } = useDisclosure(false)
 
   const {

--- a/src/components/DecisionTree/DecisionTemplate.tsx
+++ b/src/components/DecisionTree/DecisionTemplate.tsx
@@ -1,25 +1,25 @@
-import React from 'react';
+import React, { PropsWithChildren } from "react"
 
-import { IDecisionTreeContext } from './DecisionTreeContext';
-import { useDecisionTree } from './useDecisionTree';
+import { IDecisionTreeContext } from "./DecisionTreeContext"
+import { useDecisionTree } from "./useDecisionTree"
 
-export interface IDecisionTemplateProps {
-  id: string;
-  nextId?: string;
-}
+export type DecisionTemplateProps = PropsWithChildren<{
+  id: string
+  nextId?: string
+}>
 
-export type DecisionTemplateFunction = IDecisionTreeContext;
+export type DecisionTemplateFunction = IDecisionTreeContext
 
-export const DecisionTemplate: React.FunctionComponent<IDecisionTemplateProps> = (props) => {
-  const { children } = props;
-  const context = useDecisionTree();
+export function DecisionTemplate(props: DecisionTemplateProps) {
+  const { children } = props
+  const context = useDecisionTree()
 
-  if (typeof children == 'function' || false) {
-    return children(context);
+  if (typeof children == "function" || false) {
+    return children(context)
   } else {
     // eslint-disable-next-line react/jsx-no-useless-fragment
-    return <React.Fragment>{children}</React.Fragment>;
+    return <React.Fragment>{children}</React.Fragment>
   }
-};
+}
 
-export default DecisionTemplate;
+export default DecisionTemplate

--- a/src/components/DecisionTree/DecisionTree.tsx
+++ b/src/components/DecisionTree/DecisionTree.tsx
@@ -1,95 +1,110 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 
-import { DecisionTemplate, IDecisionTemplateProps } from './DecisionTemplate';
-import { DecisionTreeContext, IDecisionTreeContext } from './DecisionTreeContext';
+import { DecisionTemplate, DecisionTemplateProps } from "./DecisionTemplate"
+import {
+  DecisionTreeContext,
+  IDecisionTreeContext,
+} from "./DecisionTreeContext"
 
 type Dictionary<T> = {
-  [key: string]: T;
-};
-
-export interface IDecisionTreeProps {
-  defaultDecisionId?: string;
+  [key: string]: T
 }
 
-export const DecisionTree: React.FunctionComponent<IDecisionTreeProps> = (props) => {
-  const { children } = props;
+export type DecisionTreeProps = PropsWithChildren<{
+  defaultDecisionId?: string
+}>
+
+export function DecisionTree(props: DecisionTreeProps) {
+  const { children } = props
 
   // Construct a dictionary of Decisions from the children to
   //  make navigating between decisions easier
-  const [decisions, setDecisions] = useState<Dictionary<IDecisionTemplateProps>>(getDecisionsDictionary(children));
+  const [decisions, setDecisions] = useState<Dictionary<DecisionTemplateProps>>(
+    getDecisionsDictionary(children)
+  )
 
   // Determine the initial decision
   //  If no defaultDecisionId prop was specified, choose the
   //  first decision tree template in the children list
-  const initialDecisionId = getDefaultDecisionId(props.defaultDecisionId, children);
+  const initialDecisionId = getDefaultDecisionId(
+    props.defaultDecisionId,
+    children
+  )
 
   // If no default decision could be determined, throw an exception
   if (!initialDecisionId) {
-    const errorMsg = 'A DecisionTree with no default decision was detected.';
+    const errorMsg = "A DecisionTree with no default decision was detected."
     // eslint-disable-next-line no-console
-    console.error(errorMsg);
-    throw new Error(errorMsg);
+    console.error(errorMsg)
+    throw new Error(errorMsg)
     // If a default decision Id was specified, but no decision matches
   } else if (!decisions[initialDecisionId]) {
-    const errorMsg = 'A DecisionTree with with a default decision Id which does not match any decision was detected.';
+    const errorMsg =
+      "A DecisionTree with with a default decision Id which does not match any decision was detected."
     // eslint-disable-next-line no-console
-    console.error(errorMsg);
-    throw new Error(errorMsg);
+    console.error(errorMsg)
+    throw new Error(errorMsg)
   }
 
-  const [defaultDecision] = useState(decisions[initialDecisionId]);
-  const [currentDecision, setCurrentDecision] = useState(defaultDecision);
+  const [defaultDecision] = useState(decisions[initialDecisionId])
+  const [currentDecision, setCurrentDecision] = useState(defaultDecision)
 
   // Track the history of all decisions made
-  const [history, setHistory] = useState<IDecisionTemplateProps[]>([]);
+  const [history, setHistory] = useState<DecisionTemplateProps[]>([])
 
   // If the children change, update the dictionary of decisions
   useEffect(() => {
-    const decisions = getDecisionsDictionary(children);
-    setDecisions(decisions);
-  }, [children]);
+    const decisions = getDecisionsDictionary(children)
+    setDecisions(decisions)
+  }, [children])
 
   // Go to any decision by Id
   const goTo = useCallback(
     (decisionId: string, skipHistory = false) => {
-      const decision = decisions[decisionId];
+      const decision = decisions[decisionId]
       if (decision) {
         if (!skipHistory) {
-          setHistory([...history, currentDecision]);
+          setHistory([...history, currentDecision])
         }
-        setCurrentDecision(decision);
+        setCurrentDecision(decision)
       } else {
-        const errorMsg = `DecisionTree attempted to navigate to a DecisionId (${decisionId}) that does not exist.`;
+        const errorMsg = `DecisionTree attempted to navigate to a DecisionId (${decisionId}) that does not exist.`
         // eslint-disable-next-line no-console
-        console.error(errorMsg);
-        throw new Error(errorMsg);
+        console.error(errorMsg)
+        throw new Error(errorMsg)
       }
     },
     [decisions, history, currentDecision]
-  );
+  )
 
   // Advance to the next Decision template
   const next = useCallback(() => {
-    const { nextId } = currentDecision;
+    const { nextId } = currentDecision
 
     if (nextId) {
-      goTo(nextId);
+      goTo(nextId)
     }
-  }, [currentDecision, goTo]);
+  }, [currentDecision, goTo])
 
   // Go to the previous Decision template
   const back = useCallback(() => {
-    const previousDecision = history.pop();
+    const previousDecision = history.pop()
     if (previousDecision) {
-      setCurrentDecision(previousDecision);
+      setCurrentDecision(previousDecision)
     }
-  }, [history]);
+  }, [history])
 
   // Reset to the initial decision
   const reset = useCallback(() => {
-    setHistory([]);
-    setCurrentDecision(defaultDecision);
-  }, [defaultDecision]);
+    setHistory([])
+    setCurrentDecision(defaultDecision)
+  }, [defaultDecision])
 
   // Construct the memoized DecisionTreeContext state to
   //  be shared using the Context API
@@ -105,7 +120,7 @@ export const DecisionTree: React.FunctionComponent<IDecisionTreeProps> = (props)
         goTo,
       } as IDecisionTreeContext),
     [currentDecision, next, back, reset, goTo, history.length]
-  );
+  )
 
   // Exclude all but the current active decision template
   return (
@@ -115,52 +130,60 @@ export const DecisionTree: React.FunctionComponent<IDecisionTreeProps> = (props)
         //   the current active decision
         React.Children.toArray(children).filter((node) => {
           if (isNodeComponentType(node, DecisionTemplate)) {
-            const { id } = (node as any).props as IDecisionTemplateProps;
-            return id === currentDecision.id;
+            const { id } = (node as any).props as DecisionTemplateProps
+            return id === currentDecision.id
           }
-          return true;
+          return true
         })
       }
     </DecisionTreeContext.Provider>
-  );
-};
+  )
+}
 
-export default DecisionTree;
+export default DecisionTree
 
 const getDecisionsDictionary = (children: React.ReactNode) => {
-  const decisions: Dictionary<IDecisionTemplateProps> = {};
+  const decisions: Dictionary<DecisionTemplateProps> = {}
 
   React.Children.forEach(children, (node) => {
     if (isNodeComponentType(node, DecisionTemplate)) {
-      const { id, nextId } = (node as any).props as IDecisionTemplateProps;
-      const decision: IDecisionTemplateProps = {
+      const { id, nextId } = (node as any).props as DecisionTemplateProps
+      const decision: DecisionTemplateProps = {
         id,
         nextId: nextId || undefined,
-      };
+      }
 
-      decisions[id] = decision;
+      decisions[id] = decision
     }
-  });
+  })
 
-  return decisions;
-};
+  return decisions
+}
 
-const getDefaultDecisionId = (defaultId: string | undefined, children: React.ReactNode) => {
-  let resultId = defaultId;
+const getDefaultDecisionId = (
+  defaultId: string | undefined,
+  children: React.ReactNode
+) => {
+  let resultId = defaultId
 
   if (!defaultId) {
-    const firstDecision = React.Children.toArray(children).find((c) => isNodeComponentType(c, DecisionTemplate));
+    const firstDecision = React.Children.toArray(children).find((c) =>
+      isNodeComponentType(c, DecisionTemplate)
+    )
 
     if (firstDecision) {
-      const props = (firstDecision as any).props as IDecisionTemplateProps;
-      resultId = props.id;
+      const props = (firstDecision as any).props as DecisionTemplateProps
+      resultId = props.id
     }
   }
 
-  return resultId;
-};
+  return resultId
+}
 
-const isNodeComponentType = (node: React.ReactNode, component: React.FunctionComponent<any>) => {
-  const child = node as any;
-  return child.type.name === component.name;
-};
+const isNodeComponentType = (
+  node: React.ReactNode,
+  component: React.FunctionComponent<any>
+) => {
+  const child = node as any
+  return child.type.name === component.name
+}

--- a/src/components/DecisionTree/DecisionTreeContext.ts
+++ b/src/components/DecisionTree/DecisionTreeContext.ts
@@ -1,9 +1,9 @@
 import { createContext } from "react"
 
-import { IDecisionTemplateProps } from "./DecisionTemplate"
+import { DecisionTemplateProps } from "./DecisionTemplate"
 
 export interface IDecisionTreeContext {
-  decision: IDecisionTemplateProps | null
+  decision: DecisionTemplateProps | null
   hasNext: boolean
   hasPrevious: boolean
   next: () => void

--- a/src/components/EditFencerDialog/EditFencerDialog.tsx
+++ b/src/components/EditFencerDialog/EditFencerDialog.tsx
@@ -18,16 +18,15 @@ import {
 import { useAccountProfile } from "$hooks/useAccountProfile"
 import { useFormHelpers } from "$hooks/useFormHelpers"
 
-export interface IEditFencerDialogProps {
+export interface EditFencerDialogProps {
   fencer?: AccountFencer
   isOpen?: boolean
   onSaved?: (fencer: IFencerFormFields) => void
   onClose: () => void
 }
 
-export const EditFencerDialog: React.FunctionComponent<
-  IEditFencerDialogProps
-> = ({ isOpen, onClose, onSaved, fencer }) => {
+export function EditFencerDialog(props: EditFencerDialogProps) {
+  const { isOpen, onClose, onSaved, fencer } = props
   const {
     account: { UserId },
   } = useAccountProfile()

--- a/src/components/ErrorPages/Route404.tsx
+++ b/src/components/ErrorPages/Route404.tsx
@@ -1,10 +1,12 @@
 import { DefaultPageLayout } from "$components/AppShell/components"
 import { BigMessage } from "$components/BigMessage"
 
-export const Route404: React.FunctionComponent = () => (
-  <DefaultPageLayout title="404" skipTitleHeading>
-    <BigMessage heading="The page does not exist">
-      Uh oh! The requested resource is missing or doesn't exist anymore.
-    </BigMessage>
-  </DefaultPageLayout>
-)
+export function Route404() {
+  return (
+    <DefaultPageLayout title="404" skipTitleHeading>
+      <BigMessage heading="The page does not exist">
+        Uh oh! The requested resource is missing or doesn't exist anymore.
+      </BigMessage>
+    </DefaultPageLayout>
+  )
+}

--- a/src/components/ErrorPages/UnauthorizedAppRole.tsx
+++ b/src/components/ErrorPages/UnauthorizedAppRole.tsx
@@ -3,14 +3,16 @@ import { Link } from "@fluentui/react-components"
 import { DefaultPageLayout } from "$components/AppShell/components"
 import { BigMessage } from "$components/BigMessage"
 
-export const UnauthorizedAppRole: React.FunctionComponent = () => (
-  <DefaultPageLayout title="Error" skipTitleHeading>
-    <BigMessage heading="You are not authorized">
-      Please contact{" "}
-      <Link href={`mailto:${import.meta.env.VITE_APP_SUPPORT_EMAIL}`}>
-        support
-      </Link>{" "}
-      for help if you feel this is incorrect.
-    </BigMessage>
-  </DefaultPageLayout>
-)
+export function UnauthorizedAppRole() {
+  return (
+    <DefaultPageLayout title="Error" skipTitleHeading>
+      <BigMessage heading="You are not authorized">
+        Please contact{" "}
+        <Link href={`mailto:${import.meta.env.VITE_APP_SUPPORT_EMAIL}`}>
+          support
+        </Link>{" "}
+        for help if you feel this is incorrect.
+      </BigMessage>
+    </DefaultPageLayout>
+  )
+}

--- a/src/components/ErrorPages/UnauthorizedClubRole.tsx
+++ b/src/components/ErrorPages/UnauthorizedClubRole.tsx
@@ -1,10 +1,12 @@
 import { DefaultPageLayout } from "$components/AppShell/components"
 import { BigMessage } from "$components/BigMessage"
 
-export const UnauthorizedClubRole: React.FunctionComponent = () => (
-  <DefaultPageLayout title="Error" skipTitleHeading>
-    <BigMessage heading="You are not authorized">
-      Your club admin can help you gain access to this page.
-    </BigMessage>
-  </DefaultPageLayout>
-)
+export function UnauthorizedClubRole() {
+  return (
+    <DefaultPageLayout title="Error" skipTitleHeading>
+      <BigMessage heading="You are not authorized">
+        Your club admin can help you gain access to this page.
+      </BigMessage>
+    </DefaultPageLayout>
+  )
+}

--- a/src/components/FencerLookupField/FencerLookupField.tsx
+++ b/src/components/FencerLookupField/FencerLookupField.tsx
@@ -25,9 +25,8 @@ export interface IFencerLookupFieldProps
   size?: PersonaSize
 }
 
-export const FencerLookupField: React.FunctionComponent<
-  IFencerLookupFieldProps
-> = ({ size, ...pickerProps }) => {
+export function FencerLookupField(props: IFencerLookupFieldProps) {
+  const { size, ...pickerProps } = props
   const client = useApolloClient()
 
   const resolveSuggestions = useCallback(

--- a/src/components/FencersManager/FencersManager.tsx
+++ b/src/components/FencersManager/FencersManager.tsx
@@ -14,7 +14,7 @@ const FencersGrid = styled.div`
   grid-template-columns: repeat(auto-fill, minmax(220px, 280px));
 `
 
-export const FencersManager: React.FunctionComponent = () => {
+export function FencersManager() {
   const { account } = useAccountProfile()
 
   const [getAccountFencers, { data: accountFencers }] =

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,16 +1,12 @@
-import React from "react"
+import React, { PropsWithChildren } from "react"
 import { useForm, SubmitHandler } from "react-hook-form"
 
-export type FormProps = {
+export type FormProps = PropsWithChildren<{
   defaultValues?: any
   onSubmit?: SubmitHandler<any>
-}
+}>
 
-export const Form: React.FunctionComponent<FormProps> = ({
-  defaultValues,
-  children,
-  onSubmit,
-}) => {
+export function Form({ defaultValues, children, onSubmit }: FormProps) {
   const { handleSubmit } = useForm({ defaultValues })
 
   return <form onSubmit={handleSubmit(onSubmit ?? (() => {}))}>{children}</form>

--- a/src/components/Form/components/FormAddressAutocomplete/FormAddressAutocomplete.tsx
+++ b/src/components/Form/components/FormAddressAutocomplete/FormAddressAutocomplete.tsx
@@ -12,9 +12,7 @@ export type FormAddressAutocompleteProps = {
   ) => void
 } & Omit<FormTextFieldProps<IProfileFormFields>, "elementRef">
 
-export const FormAddressAutocomplete: React.FunctionComponent<
-  FormAddressAutocompleteProps
-> = (props) => {
+export function FormAddressAutocomplete(props: FormAddressAutocompleteProps) {
   const { name, control, controllerProps, onPlaceSelected, ...inputProps } =
     props
 

--- a/src/components/Form/components/FormDatePicker/FormDatePicker.tsx
+++ b/src/components/Form/components/FormDatePicker/FormDatePicker.tsx
@@ -4,9 +4,7 @@ import { Controller } from "react-hook-form"
 
 export type FormDatePickerProps = FormFieldProps<IDatePickerProps>
 
-export const FormDatePicker: React.FunctionComponent<FormDatePickerProps> = (
-  props
-) => {
+export function FormDatePicker(props: FormDatePickerProps) {
   const { name, control, controllerProps, onChange, onBlur, ...inputProps } =
     props
 

--- a/src/components/Form/components/FormDropdown/FormDropdown.tsx
+++ b/src/components/Form/components/FormDropdown/FormDropdown.tsx
@@ -7,9 +7,7 @@ export type FormDropdownProps<TForm extends FieldValues = any> = FormFieldProps<
   TForm
 >
 
-export const FormDropdown: React.FunctionComponent<FormDropdownProps> = (
-  props
-) => {
+export function FormDropdown(props: FormDropdownProps) {
   const { name, control, controllerProps, onChange, onBlur, ...inputProps } =
     props
 

--- a/src/components/Form/components/FormFencerLookupField/FormFencerLookupField.tsx
+++ b/src/components/Form/components/FormFencerLookupField/FormFencerLookupField.tsx
@@ -8,9 +8,7 @@ import {
 
 export type FormFencerLookupFieldProps = FormFieldProps<IFencerLookupFieldProps>
 
-export const FormFencerLookupField: React.FunctionComponent<
-  FormFencerLookupFieldProps
-> = (props) => {
+export function FormFencerLookupField(props: FormFencerLookupFieldProps) {
   const { name, control, controllerProps, onChange, onBlur, ...inputProps } =
     props
 

--- a/src/components/Form/components/FormMaskedTextField/FormMaskedTextField.tsx
+++ b/src/components/Form/components/FormMaskedTextField/FormMaskedTextField.tsx
@@ -4,36 +4,35 @@ import { Controller } from "react-hook-form"
 
 export type FormMaskedTextFieldProps = FormFieldProps<IMaskedTextFieldProps>
 
-export const FormMaskedTextField: React.FunctionComponent<FormMaskedTextFieldProps> =
-  (props) => {
-    const { name, control, controllerProps, onChange, onBlur, ...inputProps } =
-      props
+export function FormMaskedTextField(props: FormMaskedTextFieldProps) {
+  const { name, control, controllerProps, onChange, onBlur, ...inputProps } =
+    props
 
-    return (
-      <Controller
-        defaultValue={inputProps.defaultValue}
-        {...controllerProps}
-        render={({ field, fieldState: { invalid, error } }) => (
-          <MaskedTextField
-            errorMessage={invalid ? error?.message : undefined}
-            {...inputProps}
-            {...field}
-            onChange={(event, value) => {
-              if (onChange) {
-                onChange(event, value)
-              }
-              field.onChange(event, value)
-            }}
-            onBlur={(event) => {
-              if (onBlur) {
-                onBlur(event)
-              }
-              field.onBlur()
-            }}
-          />
-        )}
-        name={name}
-        control={control}
-      />
-    )
-  }
+  return (
+    <Controller
+      defaultValue={inputProps.defaultValue}
+      {...controllerProps}
+      render={({ field, fieldState: { invalid, error } }) => (
+        <MaskedTextField
+          errorMessage={invalid ? error?.message : undefined}
+          {...inputProps}
+          {...field}
+          onChange={(event, value) => {
+            if (onChange) {
+              onChange(event, value)
+            }
+            field.onChange(event, value)
+          }}
+          onBlur={(event) => {
+            if (onBlur) {
+              onBlur(event)
+            }
+            field.onBlur()
+          }}
+        />
+      )}
+      name={name}
+      control={control}
+    />
+  )
+}

--- a/src/components/Form/components/FormMemberLookupField/FormMemberLookupField.tsx
+++ b/src/components/Form/components/FormMemberLookupField/FormMemberLookupField.tsx
@@ -8,9 +8,7 @@ import { FormFieldProps } from "$components/Form/Form.types"
 
 export type FormMemberLookupFieldProps = FormFieldProps<IMemberLookupFieldProps>
 
-export const FormMemberLookupField: React.FunctionComponent<
-  FormMemberLookupFieldProps
-> = (props) => {
+export function FormMemberLookupField(props: FormMemberLookupFieldProps) {
   const { name, control, controllerProps, onChange, onBlur, ...inputProps } =
     props
 

--- a/src/components/Form/components/FormRow/FormRow.tsx
+++ b/src/components/Form/components/FormRow/FormRow.tsx
@@ -1,8 +1,9 @@
 import { Stack } from "@fluentui/react"
+import { PropsWithChildren } from "react"
 
 const rowTokens = { childrenGap: 50 }
 
-export const FormRow: React.FunctionComponent = ({ children }) => {
+export function FormRow({ children }: PropsWithChildren<{}>) {
   return (
     <Stack horizontal tokens={rowTokens}>
       {children}

--- a/src/components/Form/components/FormSection/FormSection.tsx
+++ b/src/components/Form/components/FormSection/FormSection.tsx
@@ -1,4 +1,5 @@
 import { Stack, IStackProps } from "@fluentui/react"
+import { PropsWithChildren } from "react"
 
 const maxWidthStyles = { maxWidth: 600 }
 
@@ -6,7 +7,7 @@ const formTokens: Partial<IStackProps> = {
   tokens: { childrenGap: 16 },
 }
 
-export const FormSection: React.FunctionComponent = ({ children }) => {
+export function FormSection({ children }: PropsWithChildren<{}>) {
   return (
     <Stack {...formTokens} style={maxWidthStyles}>
       {children}

--- a/src/components/Form/components/FormTextField/FormTextField.tsx
+++ b/src/components/Form/components/FormTextField/FormTextField.tsx
@@ -5,9 +5,7 @@ import { Controller, FieldValues } from "react-hook-form"
 export type FormTextFieldProps<TForm extends FieldValues = any> =
   FormFieldProps<ITextFieldProps, TForm>
 
-export const FormTextField: React.FunctionComponent<FormTextFieldProps> = (
-  props
-) => {
+export function FormTextField(props: FormTextFieldProps) {
   const { name, control, controllerProps, onChange, onBlur, ...inputProps } =
     props
 

--- a/src/components/Forms/AddressForm/AddressForm.tsx
+++ b/src/components/Forms/AddressForm/AddressForm.tsx
@@ -16,9 +16,7 @@ interface IAddressFormProps {
   form: UseFormReturn<IProfileFormFields, object>
 }
 
-export const AddressForm: React.FunctionComponent<IAddressFormProps> = ({
-  form,
-}) => {
+export function AddressForm({ form }: IAddressFormProps) {
   const { setFormFields } = useFormHelpers(form)
   const { control } = form
 

--- a/src/components/Forms/FencerForm/FencerForm.tsx
+++ b/src/components/Forms/FencerForm/FencerForm.tsx
@@ -8,13 +8,11 @@ import { FormRow } from "$components/Form/components/FormRow"
 import { FormSection } from "$components/Form/components/FormSection"
 import { FormTextField } from "$components/Form/components/FormTextField"
 
-interface IFencerFormProps {
+type FencerFormProps = {
   form: UseFormReturn<IProfileFormFields, object>
 }
 
-export const FencerForm: React.FunctionComponent<IFencerFormProps> = ({
-  form,
-}) => {
+export function FencerForm({ form }: FencerFormProps) {
   const { control } = form
 
   return (

--- a/src/components/Forms/PaymentMethodForm/PaymentMethodForm.tsx
+++ b/src/components/Forms/PaymentMethodForm/PaymentMethodForm.tsx
@@ -5,26 +5,22 @@ import {
   useElements,
   useStripe,
 } from "@stripe/react-stripe-js"
-import { FormEvent } from "react"
+import { FormEvent, PropsWithChildren } from "react"
 import { Button } from "@fluentui/react-components"
 
 // Sample code:
 // https://github.com/stripe-samples/saving-card-without-payment/blob/14749ed3cf830ba307924092b9ca3e0d4ae726ef/client/script.js
-
-export interface IPaymentMethodFormProps {}
 
 const stripePromise = loadStripe(
   //"pk_test_51Jyr98IdrFHHtGoGwIGJkd5OLVshsJT0sgV3BREw0aMyPthBV1TiLCWOTKr666HeSs1Y8yBgvVphoweVp9XxnVzN00bY4jDgw6"
   "pk_live_51Jyr98IdrFHHtGoGIVzQUqX04KyrZIB8dacM56ARIMtRqAMqUIKvL3ZHF7P9ujeNnPYaCSpNSByliUei4EtBE9gQ00ubuKijiH"
 )
 
-export const ElementsProvider: React.FunctionComponent = ({ children }) => {
+export function ElementsProvider({ children }: PropsWithChildren<{}>) {
   return <Elements stripe={stripePromise}>{children}</Elements>
 }
 
-export const PaymentMethodForm: React.FunctionComponent<
-  IPaymentMethodFormProps
-> = (props) => {
+export function PaymentMethodForm() {
   const stripe = useStripe()
   const elements = useElements()
 

--- a/src/components/Forms/ProfileForm/ProfileForm.tsx
+++ b/src/components/Forms/ProfileForm/ProfileForm.tsx
@@ -26,7 +26,7 @@ export const TabText = styled(Text)`
   margin: 0 0 1rem 1rem;
 `
 
-export const ProfileForm: React.FunctionComponent = () => {
+export function ProfileForm() {
   const form = useForm<IProfileFormFields>()
   const { setFormFields, sanitizePhone, sanitizePostal } = useFormHelpers(form)
   const { account, loading } = useAccountProfile()

--- a/src/components/LinkAssociationPanel/LinkAssociationPanel.tsx
+++ b/src/components/LinkAssociationPanel/LinkAssociationPanel.tsx
@@ -18,7 +18,7 @@ interface IAssociationMembershipForm extends FieldValues {
   personas: IAssociationMemberPersona[]
 }
 
-interface ILinkAssociationPanelProps {
+type LinkAssociationPanelProps = {
   fencerId: string
   defaultFilter?: string
   associationId?: string | null
@@ -27,9 +27,9 @@ interface ILinkAssociationPanelProps {
   onClose: () => void
 }
 
-export const LinkAssociationPanel: React.FunctionComponent<
-  ILinkAssociationPanelProps
-> = ({ associationId, fencerId, defaultFilter, onClose, onSaved, isOpen }) => {
+export function LinkAssociationPanel(props: LinkAssociationPanelProps) {
+  const { associationId, fencerId, defaultFilter, onClose, onSaved, isOpen } =
+    props
   const {
     account: { UserId },
   } = useAccountProfile()

--- a/src/components/LinkButton/LinkButton.tsx
+++ b/src/components/LinkButton/LinkButton.tsx
@@ -12,7 +12,7 @@ UnstyledButton.defaultProps = {
 
 type LinkButtonProps = ButtonProps & { href: string }
 
-export const LinkButton: React.FunctionComponent<LinkButtonProps> = (props) => {
+export function LinkButton(props: LinkButtonProps) {
   const { children, ...buttonProps } = props
   const { onClick, onMouseOver } = useLinkShims()
 

--- a/src/components/MemberLookupField/MemberLookupField.tsx
+++ b/src/components/MemberLookupField/MemberLookupField.tsx
@@ -22,9 +22,8 @@ export interface IMemberLookupFieldProps
   size?: PersonaSize
 }
 
-export const MemberLookupField: React.FunctionComponent<
-  IMemberLookupFieldProps
-> = ({ size, defaultFilter = "%", ...pickerProps }) => {
+export function MemberLookupField(props: IMemberLookupFieldProps) {
+  const { size, defaultFilter = "%", ...pickerProps } = props
   const client = useApolloClient()
 
   // TODO: Enable "show more" suggestions

--- a/src/components/MetricAdapter/MetricAdapter.tsx
+++ b/src/components/MetricAdapter/MetricAdapter.tsx
@@ -1,11 +1,10 @@
 import { OneToTenDecimalSlider } from "./components/OneToTenDecimalSlider"
 import { OneToTenRadios } from "./components/OneToTenRadios"
-import { IMetricAdapterProps } from "./MetricAdapter.types"
+import { MetricAdapterProps } from "./MetricAdapter.types"
 
-export const MetricAdapter: React.FunctionComponent<IMetricAdapterProps> = (
-  props
-) => {
+export function MetricAdapter(props: MetricAdapterProps) {
   const { type, ...fieldProps } = props
+
   switch (type) {
     case "1-10-radios":
       return <OneToTenRadios {...fieldProps} />

--- a/src/components/MetricAdapter/MetricAdapter.types.tsx
+++ b/src/components/MetricAdapter/MetricAdapter.types.tsx
@@ -1,6 +1,6 @@
 import { ControllerRenderProps, FieldValues } from "react-hook-form"
 
-export interface IMetricAdapterProps {
+export type MetricAdapterProps = {
   type: string
   required?: boolean
   disabled?: boolean

--- a/src/components/MetricAdapter/components/OneToTenDecimalSlider/OneToTenDecimalSlider.tsx
+++ b/src/components/MetricAdapter/components/OneToTenDecimalSlider/OneToTenDecimalSlider.tsx
@@ -1,9 +1,9 @@
-import { IMetricAdapterProps } from "$components/MetricAdapter/MetricAdapter.types"
+import { MetricAdapterProps } from "$components/MetricAdapter/MetricAdapter.types"
 import { Label, Slider, useId, SpinButton } from "@fluentui/react-components"
 
-export const OneToTenDecimalSlider: React.FunctionComponent<
-  Omit<IMetricAdapterProps, "type">
-> = (props) => {
+type OneToTenDecimalSliderProps = Omit<MetricAdapterProps, "type">
+
+export function OneToTenDecimalSlider(props: OneToTenDecimalSliderProps) {
   const { field, disabled, required } = props
   const id = useId("metric")
 

--- a/src/components/MetricAdapter/components/OneToTenRadios/OneToTenRadios.tsx
+++ b/src/components/MetricAdapter/components/OneToTenRadios/OneToTenRadios.tsx
@@ -1,9 +1,9 @@
-import { IMetricAdapterProps } from "$components/MetricAdapter/MetricAdapter.types"
+import { MetricAdapterProps } from "$components/MetricAdapter/MetricAdapter.types"
 import { Label, Radio, RadioGroup, useId } from "@fluentui/react-components"
 
-export const OneToTenRadios: React.FunctionComponent<
-  Omit<IMetricAdapterProps, "type">
-> = (props) => {
+type OneToTenRadiosProps = Omit<MetricAdapterProps, "type">
+
+export function OneToTenRadios(props: OneToTenRadiosProps) {
   const { field, disabled, required } = props
   const id = useId("metric")
 

--- a/src/components/OnboardingGate/OnboardingGate.tsx
+++ b/src/components/OnboardingGate/OnboardingGate.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled"
 import { AnimationStyles, Spinner, SpinnerSize, Stack } from "@fluentui/react"
+import { PropsWithChildren } from "react"
 
 import { useAccountProfile } from "$hooks/useAccountProfile"
 
@@ -9,7 +10,7 @@ const AnimatedStack = styled(Stack)`
   width: 100vw;
 `
 
-export const OnboardingGate: React.FunctionComponent = ({ children }) => {
+export function OnboardingGate({ children }: PropsWithChildren<{}>) {
   const { loading, account } = useAccountProfile()
 
   if (loading) {

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -1,12 +1,15 @@
 import styled from "@emotion/styled"
 import { Title2 } from "@fluentui/react-components"
+import { PropsWithChildren } from "react"
 
 const Title = styled(Title2)`
   margin: 0 0 1rem 0;
 `
 
-export const PageTitle: React.FunctionComponent = ({ children }) => (
-  <Title as="h1" block>
-    {children}
-  </Title>
-)
+export function PageTitle({ children }: PropsWithChildren<{}>) {
+  return (
+    <Title as="h1" block>
+      {children}
+    </Title>
+  )
+}

--- a/src/components/PaymentMethod/PaymentMethod.tsx
+++ b/src/components/PaymentMethod/PaymentMethod.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled"
 import { Badge, Text } from "@fluentui/react-components"
 import { PaymentMethod as StripePayment } from "@stripe/stripe-js"
 import { lighten } from "polished"
+import { PropsWithChildren } from "react"
 
 const PaymentCard = styled.button<{ primaryColor: string }>`
   // Remove user agent button styles
@@ -107,19 +108,15 @@ const DefaultBadge = styled(Badge)`
   border: none;
 `
 
-export interface IPaymentMethodProps {
+export type PaymentMethodProps = PropsWithChildren<{
   card: StripePayment.Card
   themeIndex?: number
   name?: string | null
   isDefault?: boolean
-}
+}>
 
-export const PaymentMethod: React.FunctionComponent<IPaymentMethodProps> = ({
-  card,
-  themeIndex,
-  name,
-  isDefault,
-}) => {
+export function PaymentMethod(props: PaymentMethodProps) {
+  const { card, themeIndex, name, isDefault } = props
   const { brand, exp_month, exp_year, last4 } = card
 
   const color = getCardColor({ index: themeIndex, last4 })

--- a/src/components/PaymentMethodsManager/PaymentMethodsManager.tsx
+++ b/src/components/PaymentMethodsManager/PaymentMethodsManager.tsx
@@ -10,7 +10,7 @@ const PaymentMethodsGrid = styled.div`
   grid-template-columns: repeat(auto-fill, 292px);
 `
 
-export const PaymentMethodsManager: React.FunctionComponent = () => {
+export function PaymentMethodsManager() {
   const { data: paymentMethods } =
     useGetPaymentMethodsQuery("cus_Kvm41gHVgqbeeS")
 

--- a/src/components/PersonaAvatar/PersonaAvatar.tsx
+++ b/src/components/PersonaAvatar/PersonaAvatar.tsx
@@ -7,14 +7,12 @@ export type PersonaAvatarProps = Omit<IPersonaProps, "size"> &
     className?: string
   }
 
-const PersonaAdapter: React.FunctionComponent<PersonaAvatarProps> = ({
-  size = 48,
-  className,
-  ...props
-}) => {
+function PersonaAdapter(props: PersonaAvatarProps) {
+  const { size = 48, className, ...personaProps } = props
+
   return (
     <Persona
-      {...props}
+      {...personaProps}
       className={className}
       size={PersonaSize.size48}
       onRenderPersonaCoin={(item) => (

--- a/src/components/ProtectedRbacRoute/ProtectedRbacRoute.tsx
+++ b/src/components/ProtectedRbacRoute/ProtectedRbacRoute.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from "react-router-dom"
-import { useMemo } from "react"
+import { PropsWithChildren, useMemo } from "react"
 
 import { UnauthorizedAppRole } from "$components/ErrorPages/UnauthorizedAppRole"
 import { UnauthorizedClubRole } from "$components/ErrorPages/UnauthorizedClubRole"
@@ -23,11 +23,9 @@ const _emptyClubRules: RbacRules<ClubRole> = {
   anyOf: [],
 }
 
-export type ProtectedRbacRouteProps = RbacPolicy
+export type ProtectedRbacRouteProps = PropsWithChildren<RbacPolicy>
 
-export const ProtectedRbacRoute: React.FunctionComponent<
-  ProtectedRbacRouteProps
-> = (props) => {
+export function ProtectedRbacRoute(props: ProtectedRbacRouteProps) {
   const {
     appRules = _emptyAppRules,
     clubRules = _emptyClubRules,

--- a/src/components/RoleBadge/RoleBadge.tsx
+++ b/src/components/RoleBadge/RoleBadge.tsx
@@ -7,9 +7,7 @@ export type RoleBadgeProps = {
   role: ClubRole
 }
 
-export const RoleBadge: React.FunctionComponent<RoleBadgeProps> = ({
-  role,
-}) => {
+export function RoleBadge({ role }: RoleBadgeProps) {
   const { getClubRoleName } = useRoleNameMappers()
   const isStaff = role !== "member"
 

--- a/src/components/RoleBadge/RoleBadgeList.tsx
+++ b/src/components/RoleBadge/RoleBadgeList.tsx
@@ -2,20 +2,17 @@ import { filterChildrenByNodeType } from "$lib/nodeUtilitities"
 import { Stack } from "@fluentui/react"
 import { Badge, Tooltip } from "@fluentui/react-components"
 import { MoreHorizontal16Regular } from "@fluentui/react-icons"
-import React from "react"
+import { PropsWithChildren } from "react"
 
 import { RoleBadge } from "./RoleBadge"
 
 const listTokens = { childrenGap: 4 }
 
-export type RoleBadgeListProps = {
+export type RoleBadgeListProps = PropsWithChildren<{
   maxItems?: number
-}
+}>
 
-export const RoleBadgeList: React.FunctionComponent<RoleBadgeListProps> = ({
-  children,
-  maxItems,
-}) => {
+export function RoleBadgeList({ children, maxItems }: RoleBadgeListProps) {
   const roles = filterChildrenByNodeType(children, RoleBadge)
   const maxRolesToShow = maxItems ?? roles.length
 

--- a/src/components/StatesDropdown/StatesDropdown.tsx
+++ b/src/components/StatesDropdown/StatesDropdown.tsx
@@ -10,9 +10,7 @@ export type StatesDropdownProps = Omit<
   "options" | "label" | "placeholder"
 >
 
-export const StatesDropdown: React.FunctionComponent<StatesDropdownProps> = (
-  props
-) => {
+export function StatesDropdown(props: StatesDropdownProps) {
   return (
     <FormDropdown
       label="State"

--- a/src/components/Tabs/TabPanel.tsx
+++ b/src/components/Tabs/TabPanel.tsx
@@ -1,9 +1,10 @@
 import { TabValue } from "@fluentui/react-components"
+import { PropsWithChildren } from "react"
 
-export type TabPanelProps = {
+export type TabPanelProps = PropsWithChildren<{
   name: TabValue
-}
+}>
 
-export const TabPanel: React.FunctionComponent<TabPanelProps> = ({
-  children,
-}) => <>{children}</>
+export function TabPanel({ children }: TabPanelProps) {
+  return <>{children}</>
+}

--- a/src/components/Tabs/TabPanelList.tsx
+++ b/src/components/Tabs/TabPanelList.tsx
@@ -1,17 +1,14 @@
 import { isNodeComponentType } from "$lib/nodeUtilitities"
 import { TabValue } from "@fluentui/react-components"
-import React from "react"
+import React, { PropsWithChildren } from "react"
 
 import { TabPanel, TabPanelProps } from "./TabPanel"
 
-export type TabPanelListProps = {
+export type TabPanelListProps = PropsWithChildren<{
   selectedPanel: TabValue
-}
+}>
 
-export const TabPanelList: React.FunctionComponent<TabPanelListProps> = ({
-  selectedPanel,
-  children,
-}) => {
+export function TabPanelList({ selectedPanel, children }: TabPanelListProps) {
   return (
     <>
       {React.Children.map(children, (element) => {

--- a/src/components/ThemedImage/ThemedImage.tsx
+++ b/src/components/ThemedImage/ThemedImage.tsx
@@ -7,9 +7,7 @@ export type ThemedImageProps = {
   darkSrc: string
 } & Omit<ImageProps, "src" | "srcSet">
 
-export const ThemedImage: React.FunctionComponent<ThemedImageProps> = (
-  props
-) => {
+export function ThemedImage(props: ThemedImageProps) {
   const { lightSrc, darkSrc, ...imageProps } = props
   const { themeName } = useAppTheme()
 

--- a/src/pages/assessments/assessment/edit.tsx
+++ b/src/pages/assessments/assessment/edit.tsx
@@ -26,7 +26,7 @@ import { PersonaAvatar } from "$components/PersonaAvatar"
 import { useTrackPisteMetric } from "$components/ApplicationInsightsProvider"
 import { DefaultPageLayout } from "$components/AppShell/components"
 
-export const EditEvaluationPage: React.FunctionComponent = () => {
+function EditEvaluationPage() {
   const pageTitle = "Edit evaluation"
   useTrackPisteMetric({ componentName: "EditEvaluationPage" })
 

--- a/src/pages/assessments/assessment/index.tsx
+++ b/src/pages/assessments/assessment/index.tsx
@@ -12,7 +12,7 @@ const PageSection = styled.div`
   margin-top: 3em;
 `
 
-const ViewAssessmentPage: React.FunctionComponent = () => {
+function ViewAssessmentPage() {
   const pageTitle = "View assessment"
   useTrackPisteMetric({ componentName: "ViewAssessmentPage" })
   const params = useParams()

--- a/src/pages/assessments/assessment/submit.tsx
+++ b/src/pages/assessments/assessment/submit.tsx
@@ -31,7 +31,7 @@ import { useDisclosure } from "$hooks/useDisclosure"
 
 // TODO: Add Notes field
 
-export const SubmitEvaluationPage: React.FunctionComponent = () => {
+function SubmitEvaluationPage() {
   const pageTitle = "Submit evaluation"
   useTrackPisteMetric({ componentName: "SubmitEvaluationPage" })
 

--- a/src/pages/assessments/index.tsx
+++ b/src/pages/assessments/index.tsx
@@ -18,7 +18,7 @@ const AssessmentsGrid = styled.div`
   grid-template-columns: repeat(auto-fill, 280px);
 `
 
-const AssessmentsPage: React.FunctionComponent = () => {
+function AssessmentsPage() {
   const pageTitle = "Assessments"
   useTrackPisteMetric({ componentName: "AssessmentsPage" })
 

--- a/src/pages/billing/index.tsx
+++ b/src/pages/billing/index.tsx
@@ -1,7 +1,7 @@
 import { useTrackPisteMetric } from "$components/ApplicationInsightsProvider"
 import { DefaultPageLayout } from "$components/AppShell/components"
 
-const BillingPage: React.FunctionComponent = () => {
+function BillingPage() {
   const pageTitle = "Billing"
   useTrackPisteMetric({ componentName: "BillingPage" })
 

--- a/src/pages/calendar/index.tsx
+++ b/src/pages/calendar/index.tsx
@@ -155,7 +155,7 @@ interface OpenHours {
   object_type: "open_hours"
 }
 
-const NylasAvailability: React.FunctionComponent = () => {
+function NylasAvailability() {
   // @ts-ignore
   useEffect(() => import("@nylas/components-availability"), [])
 
@@ -170,7 +170,7 @@ const NylasAvailability: React.FunctionComponent = () => {
   )
 }
 
-const CalendarPage: React.FunctionComponent = () => {
+function CalendarPage() {
   const pageTitle = "Calendar"
   useTrackPisteMetric({ componentName: "CalendarPage" })
 

--- a/src/pages/clubs/index.tsx
+++ b/src/pages/clubs/index.tsx
@@ -1,7 +1,7 @@
 import { useTrackPisteMetric } from "$components/ApplicationInsightsProvider"
 import { DefaultPageLayout } from "$components/AppShell/components"
 
-const ClubsPage: React.FunctionComponent = () => {
+function ClubsPage() {
   const pageTitle = "Clubs"
   useTrackPisteMetric({ componentName: "ClubsPage" })
 

--- a/src/pages/overview/index.tsx
+++ b/src/pages/overview/index.tsx
@@ -17,7 +17,7 @@ const GridContainer = styled.div`
   margin-top: 2em;
 `
 
-const OverviewPage: React.FunctionComponent = () => {
+function OverviewPage() {
   const pageTitle = "Overview"
   useTrackPisteMetric({ componentName: "OverviewPage" })
 

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -13,7 +13,7 @@ const ProfileTabs = styled(TabList)`
   margin-bottom: 1rem;
 `
 
-export const ProfilePage: React.FunctionComponent = () => {
+function ProfilePage() {
   const pageTitle = "Profile"
   useTrackPisteMetric({ componentName: "ProfilePage" })
 

--- a/src/pages/tournaments/index.tsx
+++ b/src/pages/tournaments/index.tsx
@@ -1,7 +1,7 @@
 import { useTrackPisteMetric } from "$components/ApplicationInsightsProvider"
 import { DefaultPageLayout } from "$components/AppShell/components"
 
-export const TournamentsPage: React.FunctionComponent = () => {
+function TournamentsPage() {
   const pageTitle = "Tournaments"
   useTrackPisteMetric({ componentName: "TournamentsPage" })
 

--- a/src/pages/users/index.tsx
+++ b/src/pages/users/index.tsx
@@ -91,7 +91,7 @@ type ClubAccount = NonNullable<
   GetClubMembersByIdQuery["club_accounts"][0]["Account"]
 >
 
-const UsersPage: React.FunctionComponent = () => {
+function UsersPage() {
   const pageTitle = "Users"
   useTrackPisteMetric({ componentName: "UsersPage" })
   const { onTabSelected, selectedTab } = useTabs("membersTab")
@@ -435,9 +435,9 @@ const UsersPage: React.FunctionComponent = () => {
 
 export default UsersPage
 
-const MemberAvatarStack: React.FunctionComponent<{ names: string[] }> = ({
-  names,
-}) => {
+type MemberAvatarStackProps = { names: string[] }
+
+function MemberAvatarStack({ names }: MemberAvatarStackProps) {
   const { inlineItems, overflowItems } = partitionAvatarGroupItems({
     items: names,
     layout: "stack",


### PR DESCRIPTION
Prefer simpler Component type definition which protects against overly wide return types, and explicitly defines Children. This is a transition from the `React.FunctionComponent` type which implicitly defines children, and also assumes a overly wide component return type (`React.ReactNode`).

This PR resolves issue https://github.com/Fencing-Club/piste-dashboard/issues/533